### PR TITLE
fix(scale, x-axis): Scale Horizontally if width is higher than height and removing zoom handlers

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,7 +16,6 @@ import React, {
 import { Background } from "./components/Background/background";
 import {
   ZOOM_CONFIGS,
-  ZOOM_CONTROLS,
   SCROLL_NODE_POSITIONS,
   COMPONENT_POSITIONS,
 } from "./helpers/constants";
@@ -28,15 +27,6 @@ import { ScrollBar } from "./components/scrollBar/scrollbar";
 const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
 const TIME_TO_WAIT = isSafari ? 600 : 300;
 
-const ZOOM_KEY_CODES = {
-  ZOOM_IN: 187,
-  ZOOM_OUT: 189,
-  ZOOM_IN_2: 61,
-  ZOOM_OUT_2: 173,
-  FIT_TO_VIEW: 48,
-  FIT_TO_HUNDRED: 49,
-};
-
 export interface ReactInfiniteCanvasProps {
   children: JSX.Element;
   ref?: any;
@@ -44,7 +34,6 @@ export interface ReactInfiniteCanvasProps {
   maxZoom?: number;
   panOnScroll?: boolean;
   renderScrollBar?: boolean;
-  onActionClick?: (action: string) => void;
   scrollBarConfig?: {
     startingPosition?: {
       x: number;
@@ -163,7 +152,6 @@ const ReactInfiniteCanvasRenderer = memo(
     renderScrollBar = true,
     scrollBarConfig = {},
     backgroundConfig = {},
-    onActionClick,
     onCanvasMount = () => {},
   }: ReactInfiniteCanvasRendererProps) => {
     const canvasWrapperRef = useRef<HTMLDivElement | null>(null);
@@ -535,91 +523,6 @@ const ReactInfiniteCanvasRenderer = memo(
         d3Zoom,
       };
     };
-
-    const handleActionClick = useCallback(
-      function actionClickHandler(actionId: string) {
-        const canvasNode = select(canvasRef.current);
-        const { k: currentScale } = d3Selection.current.property("__zoom");
-        switch (actionId) {
-          case ZOOM_CONTROLS.FIT_TO_VIEW:
-            fitContentToView({});
-            break;
-
-          case ZOOM_CONTROLS.FIT_TO_HUNDRED:
-            d3Zoom.scaleTo(
-              // @ts-ignore
-              canvasNode.transition().duration(ZOOM_CONFIGS.TIME_FRAME),
-              1
-            );
-            break;
-
-          case ZOOM_CONTROLS.ZOOM_IN:
-            d3Zoom.scaleTo(
-              // @ts-ignore
-              canvasNode.transition().duration(ZOOM_CONFIGS.TIME_FRAME),
-              currentScale + ZOOM_CONFIGS.ZOOM_RATIO
-            );
-            break;
-
-          case ZOOM_CONTROLS.ZOOM_OUT:
-            d3Zoom.scaleTo(
-              // @ts-ignore
-              canvasNode.transition().duration(ZOOM_CONFIGS.TIME_FRAME),
-              currentScale - ZOOM_CONFIGS.ZOOM_RATIO
-            );
-            break;
-
-          default:
-            break;
-        }
-      },
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-      [fitContentToView]
-    );
-
-    useEffect(
-      function zoomShortcutHandler() {
-        function onKeyDownHandler(e: KeyboardEvent) {
-          const cmdPressed = e.metaKey || e.ctrlKey;
-          if (!Object.values(ZOOM_KEY_CODES).includes(e.which) || !cmdPressed)
-            return;
-          e.preventDefault();
-          switch (e.which) {
-            case ZOOM_KEY_CODES.ZOOM_IN:
-            case ZOOM_KEY_CODES.ZOOM_IN_2:
-              onActionClick
-                ? onActionClick(ZOOM_CONTROLS.ZOOM_IN)
-                : handleActionClick(ZOOM_CONTROLS.ZOOM_IN);
-              break;
-            case ZOOM_KEY_CODES.ZOOM_OUT:
-            case ZOOM_KEY_CODES.ZOOM_OUT_2:
-              onActionClick
-                ? onActionClick(ZOOM_CONTROLS.ZOOM_OUT)
-                : handleActionClick(ZOOM_CONTROLS.ZOOM_OUT);
-              break;
-            case ZOOM_KEY_CODES.FIT_TO_VIEW:
-              onActionClick
-                ? onActionClick(ZOOM_CONTROLS.FIT_TO_VIEW)
-                : handleActionClick(ZOOM_CONTROLS.FIT_TO_VIEW);
-              break;
-            case ZOOM_KEY_CODES.FIT_TO_HUNDRED:
-              onActionClick
-                ? onActionClick(ZOOM_CONTROLS.FIT_TO_HUNDRED)
-                : handleActionClick(ZOOM_CONTROLS.FIT_TO_HUNDRED);
-              break;
-            default:
-              return;
-          }
-        }
-
-        window.addEventListener("keydown", onKeyDownHandler);
-        return () => {
-          window.removeEventListener("keydown", onKeyDownHandler);
-        };
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-      },
-      [onActionClick, handleActionClick]
-    );
 
     const onMouseDown = () => {
       const bodyElement = document.body;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -44,6 +44,7 @@ export interface ReactInfiniteCanvasProps {
   maxZoom?: number;
   panOnScroll?: boolean;
   renderScrollBar?: boolean;
+  onActionClick?: (action: string) => void;
   scrollBarConfig?: {
     startingPosition?: {
       x: number;
@@ -162,6 +163,7 @@ const ReactInfiniteCanvasRenderer = memo(
     renderScrollBar = true,
     scrollBarConfig = {},
     backgroundConfig = {},
+    onActionClick,
     onCanvasMount = () => {},
   }: ReactInfiniteCanvasRendererProps) => {
     const canvasWrapperRef = useRef<HTMLDivElement | null>(null);
@@ -268,7 +270,7 @@ const ReactInfiniteCanvasRenderer = memo(
             scale,
             shouldUpdateMaxScale,
             maxScale,
-            transitionDuration
+            transitionDuration,
           }: {
             nodeElement?: HTMLElement;
             offset?: { x: number; y: number };
@@ -519,7 +521,7 @@ const ReactInfiniteCanvasRenderer = memo(
       };
     };
 
-    const onActionClick = useCallback(
+    const handleActionClick = useCallback(
       function actionClickHandler(actionId: string) {
         const canvasNode = select(canvasRef.current);
         const { k: currentScale } = d3Selection.current.property("__zoom");
@@ -570,17 +572,25 @@ const ReactInfiniteCanvasRenderer = memo(
           switch (e.which) {
             case ZOOM_KEY_CODES.ZOOM_IN:
             case ZOOM_KEY_CODES.ZOOM_IN_2:
-              onActionClick(ZOOM_CONTROLS.ZOOM_IN);
+              onActionClick
+                ? onActionClick(ZOOM_CONTROLS.ZOOM_IN)
+                : handleActionClick(ZOOM_CONTROLS.ZOOM_IN);
               break;
             case ZOOM_KEY_CODES.ZOOM_OUT:
             case ZOOM_KEY_CODES.ZOOM_OUT_2:
-              onActionClick(ZOOM_CONTROLS.ZOOM_OUT);
+              onActionClick
+                ? onActionClick(ZOOM_CONTROLS.ZOOM_OUT)
+                : handleActionClick(ZOOM_CONTROLS.ZOOM_OUT);
               break;
             case ZOOM_KEY_CODES.FIT_TO_VIEW:
-              onActionClick(ZOOM_CONTROLS.FIT_TO_VIEW);
+              onActionClick
+                ? onActionClick(ZOOM_CONTROLS.FIT_TO_VIEW)
+                : handleActionClick(ZOOM_CONTROLS.FIT_TO_VIEW);
               break;
             case ZOOM_KEY_CODES.FIT_TO_HUNDRED:
-              onActionClick(ZOOM_CONTROLS.FIT_TO_HUNDRED);
+              onActionClick
+                ? onActionClick(ZOOM_CONTROLS.FIT_TO_HUNDRED)
+                : handleActionClick(ZOOM_CONTROLS.FIT_TO_HUNDRED);
               break;
             default:
               return;
@@ -593,7 +603,7 @@ const ReactInfiniteCanvasRenderer = memo(
         };
         // eslint-disable-next-line react-hooks/exhaustive-deps
       },
-      [onActionClick]
+      [onActionClick, handleActionClick]
     );
 
     const onMouseDown = () => {
@@ -642,7 +652,11 @@ const ReactInfiniteCanvasRenderer = memo(
             </svg>
           )}
         </div>
-        <Background maxZoom={maxZoom} zoomTransform={zoomTransform} {...backgroundConfig} />
+        <Background
+          maxZoom={maxZoom}
+          zoomTransform={zoomTransform}
+          {...backgroundConfig}
+        />
         {renderScrollBar && canvasWrapperRef.current && (
           <ScrollBar
             ref={scrollBarRef}

--- a/src/helpers/constants.ts
+++ b/src/helpers/constants.ts
@@ -12,21 +12,14 @@ export const ZOOM_CONFIGS = {
   INITIAL_SCROLLBAR_SIZE: 50,
   MIN_SCROLLBAR_SIZE: 15,
   SCROLL_DELTA_DIFF: 1.5,
-  NODE_Y_OFFSET: 110
-};
-
-export const ZOOM_CONTROLS = {
-  ZOOM_IN: "zoom-in",
-  ZOOM_OUT: "zoom-out",
-  FIT_TO_VIEW: "fit-to-view",
-  FIT_TO_HUNDRED: "fit-to-100"
+  NODE_Y_OFFSET: 110,
 };
 
 export const COMPONENT_POSITIONS = {
   TOP_LEFT: "top-left",
   TOP_RIGHT: "top-right",
   BOTTOM_LEFT: "bottom-left",
-  BOTTOM_CENTER: "bottom-center"
+  BOTTOM_CENTER: "bottom-center",
 };
 
 export const SCROLL_NODE_POSITIONS = {


### PR DESCRIPTION
Fit Scale Horizontally: 9316f64cf808c9416bf1688b7a276464e2b0306e
Previously, we are trying to fit the height in the view but not width, so fixing that
And adding a new param `disableVerticalCenter` to disable translate vertically center even if height is higher than width.


Removal of zoom handlers through keyboard keys, rather it can be handled by consumer 2bc23011d4c07e113894942322df59c58d9ae33d

