### PR TITLE
Feat block pan

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-infinite-canvas",
-  "version": "1.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-infinite-canvas",
-      "version": "1.0.0",
+      "version": "2.1.0",
       "license": "MIT",
       "devDependencies": {
         "@types/d3-selection": "^3.0.10",
@@ -26,9 +26,12 @@
         "vite-plugin-css-injected-by-js": "^3.4.0",
         "vite-plugin-dts": "^3.7.3"
       },
+      "engines": {
+        "node": ">=10"
+      },
       "peerDependencies": {
-        "react": "^17.0.0",
-        "react-dom": "^17.0.0"
+        "react": ">=16",
+        "react-dom": ">=16"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -215,7 +215,7 @@ const ReactInfiniteCanvasRenderer = memo(
           : {};
 
         d3Zoom
-          .filter(function(event: { type: string; ctrlKey: any }) {
+          .filter((event: { type: string; ctrlKey: any }) => {
             if (event.type === "mousedown" && !isUserPressed.current) {
               isUserPressed.current = true;
               onMouseDown();
@@ -225,11 +225,11 @@ const ReactInfiniteCanvasRenderer = memo(
           })
           .on(
             "zoom",
-            function(event: {
+            (event: {
               sourceEvent: { ctrlKey: boolean };
               type: string;
               transform: any;
-            }) {
+            }) => {
               const nativeTarget = event.sourceEvent?.target;
               if (nativeTarget && shouldBlockPanEvent({target: nativeTarget})) return;
               onZoom(event);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -154,8 +154,7 @@ const ReactInfiniteCanvasRenderer = memo(
     renderScrollBar = true,
     scrollBarConfig = {},
     backgroundConfig = {},
-    onCanvasMount = () => {},
-    onZoom = () => {}
+    onCanvasMount = () => {},    
   }: ReactInfiniteCanvasRendererProps) => {
     const canvasWrapperRef = useRef<HTMLDivElement | null>(null);
     const canvasWrapperBounds = useRef<any>(null);
@@ -232,8 +231,7 @@ const ReactInfiniteCanvasRenderer = memo(
               transform: any;
             }) => {
               const nativeTarget = event.sourceEvent?.target;
-              if (nativeTarget && shouldBlockPanEvent({target: nativeTarget})) return;
-              onZoom(event);
+              if (nativeTarget && shouldBlockPanEvent({target: nativeTarget})) return;              
 
               if (
                 event.sourceEvent?.ctrlKey === false &&

--- a/src/components/EventBlocker/event.blocker.tsx
+++ b/src/components/EventBlocker/event.blocker.tsx
@@ -4,13 +4,17 @@ export interface EventBlockerProps {
   children: React.ReactNode;
   shouldBlockScroll?: boolean;
   shouldBlockZoom?: boolean;
+  shouldBlockPan?: boolean;
 }
 
 export const EventBlocker: React.FC<EventBlockerProps> = ({
   children,
   shouldBlockScroll = true,
   shouldBlockZoom = true,
+  shouldBlockPan = true
 }) => {
-  const blockClassName = getBlockClassName(shouldBlockScroll, shouldBlockZoom);
-  return <div className={`${blockClassName}`}>{children}</div>;
+  const blockClassName = getBlockClassName(shouldBlockScroll, shouldBlockZoom, shouldBlockPan);
+  return <div className={`${blockClassName}`}>
+    {children}
+  </div>;
 };

--- a/src/helpers/constants.ts
+++ b/src/helpers/constants.ts
@@ -35,4 +35,5 @@ export const BLOCK_EVENTS_CLASS = {
   BLOCK_EVENTS: "react-infinite-canvas-block-events",
   BLOCK_SCROLL_CLASS: "react-infinite-canvas-block-scroll",
   BLOCK_ZOOM_CLASS: "react-infinite-canvas-block-zoom",
+  BLOCK_PAN_CLASS: "react-infinite-canvas-block-pan",
 }

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -291,17 +291,33 @@ export const onScrollHandler = ({
 
 export const getBlockClassName = (
   shouldBlockScroll: boolean,
-  shouldBlockZoom: boolean
+  shouldBlockZoom: boolean,
+  shouldBlockPan: boolean
 ) => {
-  let blockClassName = "";
-  if (shouldBlockScroll && shouldBlockZoom) {
-    blockClassName = `${BLOCK_EVENTS_CLASS.BLOCK_EVENTS}`;
-  } else if (shouldBlockScroll) {
-    blockClassName = `${BLOCK_EVENTS_CLASS.BLOCK_SCROLL_CLASS}`;
-  } else if (shouldBlockZoom) {
-    blockClassName = `${BLOCK_EVENTS_CLASS.BLOCK_ZOOM_CLASS}`;
+  if (shouldBlockScroll && shouldBlockZoom && shouldBlockPan) {
+    return `${BLOCK_EVENTS_CLASS.BLOCK_EVENTS}`;
   }
+
+  return [
+    shouldBlockScroll && `${BLOCK_EVENTS_CLASS.BLOCK_SCROLL_CLASS}`,
+    shouldBlockZoom && `${BLOCK_EVENTS_CLASS.BLOCK_ZOOM_CLASS}`,
+    shouldBlockPan && `${BLOCK_EVENTS_CLASS.BLOCK_PAN_CLASS}`,
+  ]
+  .filter(Boolean)
+  .join(" ");
   return blockClassName;
+};
+
+export const shouldBlockPanEvent = (event: {
+  target: HTMLElement;
+}) => {
+  const target = event.target as HTMLElement;
+  if (
+    target.closest(`.${BLOCK_EVENTS_CLASS.BLOCK_PAN_CLASS}`)
+  ) {
+    return true;
+  }
+  return false;
 };
 
 export const shouldBlockEvent = (event: {


### PR DESCRIPTION
## Describe your changes

Add a `shouldBlockPanEvent` prop to the `EventBlocker` so all events can be blocked.
The `onZoom` is optional but also helpful for updating childs in a drawing app e.g. apply new scaling.

Which issue does this fix? As mentioned in #8 it is not fixing but an useful addtion for a drawing like use-case.

@KarthikAravindR please review and test. Let me know if there is anything to improve.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] Code follows coding conventions held in this repo
- [ ] Docs have been updated (if applicable)

